### PR TITLE
fix: 使用FilePath上传文件时报错，处理当response为空时产生的错误。

### DIFF
--- a/sdk/base.js
+++ b/sdk/base.js
@@ -887,6 +887,7 @@ function putObject(params, callback) {
 
     if (FilePath) {
         readStream = fs.createReadStream(FilePath); // 传入 './1mb.zip'
+        Body = readStream;
         headers['Content-Length'] = fs.statSync(FilePath).size;
     } else if (Body && typeof Body.pipe === 'function') { // fs.createReadStream(filepath)
         readStream = Body;
@@ -1644,6 +1645,10 @@ function submitRequest(params, callback) {
 
         // 返回内容添加 状态码 和 headers
         var cb = function (err, data) {
+            if (err && !response) {
+              callback(err, null);
+              return;
+            }
             data = data || {};
             data.statusCode = response.statusCode;
             data.headers = response.headers;


### PR DESCRIPTION
当Body为文件路径时，会触发`write after end`错误，此时response为空。