### PR TITLE
修复SignatureDoesNotMatch的403签名BUG

### DIFF
--- a/sdk/util.js
+++ b/sdk/util.js
@@ -95,7 +95,7 @@ var getAuth = function (opt) {
     var stringToSign = ['sha1', qSignTime, res, ''].join('\n');
 
     // 步骤四：计算 Signature
-    var qSignature = crypto.createHmac('sha1', signKey).update(stringToSign).digest('hex');
+    var qSignature = crypto.createHmac('sha1', signKey).update(stringToSign);
 
     // 步骤五：构造 Authorization
     var authorization = [


### PR DESCRIPTION
计算签名方法里，额外的 `.digest('hex')` 会导致`SignatureDoesNotMatch`签名不匹配的403错误，为了说明这个问题，我创建了一个[Demo](https://github.com/HaoChuan9421/cos-demo)。`utils/getAuth.js`目录下的代码是复制自本项目的`util.js`。你可以通过添加删除`.digest('hex')`来进行验证。