### PR TITLE
解决当有传入Output参数时getObject()方法回调函数执行时机不准确的问题

### DIFF
--- a/sdk/base.js
+++ b/sdk/base.js
@@ -3395,7 +3395,7 @@ function _submitRequest(params, callback) {
         params.outputStream.on('error', function (err) {
             sender && sender.abort && sender.abort();
             cb(err)
-        }).on('finish', () => {
+        }).on('finish', function () {
             // 当有传入outputStream时，在它的finish事件抛出时执行成功回调，该时间点可以保证文件已经下载并完全写入了磁盘
             cb(null, {});
         });


### PR DESCRIPTION
getObject方法当传入了Output参数时，应该在文件下载完成并且完全写入了磁盘之后再执行成功回调，但是目前该方法是在request的end事件中执行的回调，这样有几率出现调用方收到下载成功的回调但实际上文件还没有完全写入磁盘的问题，如果此时业务逻辑中紧接着对文件进行操作（比如复制等）就会出现错误，如复制的zip文件无法解压等。
针对这种情况，更准确的做法应该是监听Output参数传入的writestream的finish事件，当该事件执行时，可以保证文件已下载并完全写入了磁盘中，这样的行为更符合调用方的预期。