### PR TITLE
Update configstore version to fix High Prototype Pollution npm issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/tencentyun/cos-nodejs-sdk-v5#readme",
   "dependencies": {
-    "configstore": "^3.1.2",
+    "configstore": "^5.0.1",
     "mime-types": "^2.1.24",
     "request": "^2.88.0",
     "xml2js": "^0.4.19"


### PR DESCRIPTION
High Prototype Pollution

Package dot-prop

Patched in >=5.1.1

Dependency of cos-nodejs-sdk-v5

Path cos-nodejs-sdk-v5 > configstore > dot-prop