### PR TITLE
fix: 修复错误的将开发环境依赖添加到正式依赖中

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,13 +30,13 @@
   },
   "homepage": "https://github.com/tencentyun/cos-nodejs-sdk-v5#readme",
   "dependencies": {
-    "@types/node": "^14.14.20",
     "conf": "^9.0.0",
     "mime-types": "^2.1.24",
     "request": "^2.88.2",
     "xml2js": "^0.4.19"
   },
   "devDependencies": {
+    "@types/node": "^14.14.20",
     "batch": "^0.6.1",
     "crc64-ecma182.js": "^1.0.0",
     "mocha": "^4.0.1",


### PR DESCRIPTION
如标题，`@types/node` 属于开发环境依赖，错误的将其添加到正式依赖中。这将导致下游依赖必定安装 `@types/node` 到 `node_modules` 的情况出现。

> 注明：这已经不是这个包第一次错误的将开发依赖添加到正式依赖中了哦，期望能稍微考虑下使用者的心情。